### PR TITLE
Remove queue group from trigger runner subscription threads on Go and Python

### DIFF
--- a/go-sdk/runner/trigger/subscriber.go
+++ b/go-sdk/runner/trigger/subscriber.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"fmt"
+	"github.com/google/uuid"
 	"os"
 	"os/signal"
 	"strings"
@@ -33,12 +34,11 @@ func (tr *Runner) startSubscriber() {
 
 		ackWaitTime := 22 * time.Hour
 
-		s, err := tr.jetstream.QueueSubscribe(
+		s, err := tr.jetstream.Subscribe(
 			subject,
-			consumerName,
 			tr.processMessage,
 			nats.DeliverNew(),
-			nats.Durable(consumerName),
+			nats.Durable(fmt.Sprintf("%s-%s", consumerName, uuid.New().String())),
 			nats.ManualAck(),
 			nats.AckWait(ackWaitTime),
 		)

--- a/py-sdk/runner/runner/trigger/subscriber.py
+++ b/py-sdk/runner/runner/trigger/subscriber.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 import loguru
 from nats.aio.msg import Msg
@@ -47,8 +48,7 @@ class TriggerSubscriber:
                 try:
                     sub = await self.trigger_runner.js.subscribe(
                         subject=subject,
-                        queue=consumer_name,
-                        durable=consumer_name,
+                        durable=consumer_name + str(uuid4()),
                         cb=self._process_message,
                         config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW, ack_wait=ack_wait_time.total_seconds()),
                         manual_ack=True,

--- a/py-sdk/runner/runner/trigger/subscriber_test.py
+++ b/py-sdk/runner/runner/trigger/subscriber_test.py
@@ -1,5 +1,7 @@
+import uuid
 from unittest.mock import AsyncMock, Mock, call, patch
 
+import mock
 import pytest
 from google.protobuf.any_pb2 import Any
 from nats.aio.client import Client as NatsClient
@@ -78,12 +80,13 @@ async def test_start_ok_str_input(m_trigger_subscriber):
     assert m_trigger_subscriber.trigger_runner.js.subscribe.called
     assert m_trigger_subscriber.trigger_runner.js.subscribe.call_args == call(
         subject=SUBJECT,
-        queue=consumer_name,
-        durable=consumer_name,
+        durable=mock.ANY,
         cb=cb_mock,
         config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW, ack_wait=float(22 * 3600)),
         manual_ack=True,
     )
+    assert (isinstance(m_trigger_subscriber.trigger_runner.js.subscribe.call_args[1]['durable'], str)
+            and m_trigger_subscriber.trigger_runner.js.subscribe.call_args[1]['durable'].startswith(consumer_name))
     assert m_trigger_subscriber.subscriptions == [m_trigger_subscriber.trigger_runner.js.subscribe.return_value]
 
 
@@ -101,21 +104,25 @@ async def test_start_ok_list_input(m_trigger_subscriber):
     assert m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list == [
         call(
             subject=SUBJECT_LIST[0],
-            queue=consumer_name,
-            durable=consumer_name,
+            durable=mock.ANY,
             cb=cb_mock,
             config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW, ack_wait=float(22 * 3600)),
             manual_ack=True,
         ),
         call(
             subject=SUBJECT_LIST[1],
-            queue=consumer_name2,
-            durable=consumer_name2,
+            durable=mock.ANY,
             cb=cb_mock,
             config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW, ack_wait=float(22 * 3600)),
             manual_ack=True,
         ),
     ]
+    assert (isinstance(m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[0][1]['durable'], str)
+            and m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[0][1]['durable'].startswith(
+                consumer_name))
+    assert (isinstance(m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[1][1]['durable'], str)
+            and m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[1][1]['durable'].startswith(
+                consumer_name2))
     assert m_trigger_subscriber.subscriptions == [
         m_trigger_subscriber.trigger_runner.js.subscribe.return_value,
         m_trigger_subscriber.trigger_runner.js.subscribe.return_value,
@@ -137,21 +144,25 @@ async def test_start_ok_str_list_input(m_trigger_subscriber):
     assert m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list == [
         call(
             subject=input_subjects[0],
-            queue=consumer_name,
-            durable=consumer_name,
+            durable=mock.ANY,
             cb=cb_mock,
             config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW, ack_wait=float(22 * 3600)),
             manual_ack=True,
         ),
         call(
             subject=input_subjects[1],
-            queue=consumer_name2,
-            durable=consumer_name2,
+            durable=mock.ANY,
             cb=cb_mock,
             config=ConsumerConfig(deliver_policy=DeliverPolicy.NEW, ack_wait=float(22 * 3600)),
             manual_ack=True,
         ),
     ]
+    assert (isinstance(m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[0][1]['durable'], str)
+            and m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[0][1]['durable'].startswith(
+                consumer_name))
+    assert (isinstance(m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[1][1]['durable'], str)
+            and m_trigger_subscriber.trigger_runner.js.subscribe.call_args_list[1][1]['durable'].startswith(
+                consumer_name2))
     assert m_trigger_subscriber.subscriptions == [
         m_trigger_subscriber.trigger_runner.js.subscribe.return_value,
         m_trigger_subscriber.trigger_runner.js.subscribe.return_value,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove queue group from trigger runner subscription threads on Go and Python

## Motivation and Context
In order to make the trigger processes compatible with the Ingress load balancing, and make them scalable, we need to remove the queue group from the subscription so that all pods receive and process all events sent from the exit nodes, and discard all events that are not meant to be processed by them.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
