### PR TITLE
fix: nats py bug workaround

### DIFF
--- a/py-sdk/sdk/sdk/ephemeral_storage/ephemeral_storage.py
+++ b/py-sdk/sdk/sdk/ephemeral_storage/ephemeral_storage.py
@@ -158,8 +158,9 @@ class EphemeralStorage(EphemeralStorageABC):
             raise UndefinedEphemeralStorageError
 
         try:
-            info_ = await self.object_store.delete(key)
-            return info_.info.deleted if info_.info.deleted else False
+            await self.object_store.delete(key)
+            # NATS python has a bug not returning anything when deleting an object
+            # return info_.info.deleted if info_.info.deleted else False
         except ObjectNotFoundError as e:
             self.logger.debug(f"file {key} not found in ephemeral storage {self.ephemeral_storage_name}: {e}")
             return False
@@ -168,6 +169,8 @@ class EphemeralStorage(EphemeralStorageABC):
                 f"failed to delete file {key} from ephemeral storage {self.ephemeral_storage_name}: {e}"
             )
             raise FailedToDeleteFileError(key=key, error=e)
+        else:
+            return True
 
     async def purge(self, regexp: Optional[str] = None) -> None:
         if not self.object_store:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
NATS python has a bug when deleting it's not returning the info object as expected

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [ ] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
